### PR TITLE
feat: make speakers job optional

### DIFF
--- a/apps/web/src/content/config.ts
+++ b/apps/web/src/content/config.ts
@@ -10,7 +10,7 @@ const speakers = defineCollection({
       type: z
         .union([z.literal("speaker"), z.literal("keynote"), z.literal("mc")])
         .optional(),
-      job: z.string(),
+      job: z.string().optional(),
       alias: z.string().optional(),
       github: z.string().optional(),
       info: z.string().optional(),

--- a/apps/web/src/pages/speakers/[slug].astro
+++ b/apps/web/src/pages/speakers/[slug].astro
@@ -58,9 +58,11 @@ const metaFields = [
           {speaker!.data.name}
         </h1>
 
-        <p class="mb-4 text-slate-400 italic text-sm">
-          {speaker!.data.job}
-        </p>
+        {
+          !!speaker.data.job && (
+            <p class="mb-4 text-slate-400 italic text-sm">{speaker.data.job}</p>
+          )
+        }
 
         <div class="max-w-[60ch] overflow-hidden mb-16">
           <div class="prose dark:prose-invert mb-6">


### PR DESCRIPTION
Makes the `job` field on the speakers collection optional and add conditional rendering to the job on the speaker page.